### PR TITLE
Llvm 4 updates

### DIFF
--- a/src/CustomTaintChecker.cpp
+++ b/src/CustomTaintChecker.cpp
@@ -25,7 +25,6 @@
 #include "TaintConfig.h"
 
 #include "clang/AST/Attr.h"
-#include "ClangSACheckers.h"
 #include "clang/Config/config.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/AST/StmtVisitor.h"

--- a/src/CustomTaintChecker.cpp
+++ b/src/CustomTaintChecker.cpp
@@ -345,9 +345,6 @@ CustomTaintChecker::getTaintPropagationRule(const FunctionDecl *FDecl,
     case Builtin::BIstrncpy:
     case Builtin::BIstrncat:
       return TaintPropagationRule(1, 2, 0, true);
-    case Builtin::BIstrlcpy:
-    case Builtin::BIstrlcat:
-      return TaintPropagationRule(1, 2, 0, false);
     case Builtin::BIstrndup:
       return TaintPropagationRule(0, 1, ReturnValueIndex);
 

--- a/src/TaintUtil.cpp
+++ b/src/TaintUtil.cpp
@@ -135,7 +135,7 @@ ProgramStateRef removeTaint(ProgramStateRef &PS, const MemRegion *R,
   return PS;
 }
 
-PathDiagnosticPiece *TaintBugVisitor::VisitNode(const ExplodedNode *N,
+std::shared_ptr<PathDiagnosticPiece> TaintBugVisitor::VisitNode(const ExplodedNode *N,
                                                 const ExplodedNode *PrevN,
                                                 BugReporterContext &BRC,
                                                 BugReport &BR) {
@@ -162,7 +162,7 @@ PathDiagnosticPiece *TaintBugVisitor::VisitNode(const ExplodedNode *N,
     char Message[70];
     sprintf(Message, "Expression '%s' gets tainted here",
             exprToString(Expression).data());
-    return new PathDiagnosticEventPiece(L, Message);
+    return std::make_shared<PathDiagnosticEventPiece>(L, Message);
   }
   return nullptr;
 }

--- a/src/includes/TaintUtil.h
+++ b/src/includes/TaintUtil.h
@@ -76,7 +76,7 @@ public:
     ID.AddPointer(Symbol);
   }
   
-  PathDiagnosticPiece *VisitNode(const ExplodedNode *N,
+  std::shared_ptr<PathDiagnosticPiece> VisitNode(const ExplodedNode *N,
                                  const ExplodedNode *PrevN,
                                  BugReporterContext &BRC,
                                  BugReport &BR) override;


### PR DESCRIPTION
The module does not build with LLVM-4.0. This patchset introduces the necessary changes for comparability with the newer version. It also allows building against pre-installed versions (e.g. no LLVM-sources necessary, just the headers and libraries provided by development packages).

Note that only LLVM/clang-4 are considered. Additional changes may be necessary for newer versions.